### PR TITLE
Quick html syntax fix. Closing a <a> tag.

### DIFF
--- a/my_app/views.py
+++ b/my_app/views.py
@@ -66,7 +66,7 @@ class SubmitView(View):
                 TemporaryMention.objects.create(url=url).save()
                 process_outgoing_webmentions(
                     '/',
-                    f'<html><body><a href="{url}"{url}</a></body></html>')
+                    f'<html><body><a href="{url}">{url}</a></body></html>')
                 return redirect('/')
 
         return HttpResponseBadRequest()


### PR DESCRIPTION
Adding a closing tag for the process_outgoing_webmentions argument (link).